### PR TITLE
chore: add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,44 @@
+# keda
+
+InfoTrack's fork of KEDA (Kubernetes Event-Driven Autoscaling). Contains InfoTrack-specific scalers and patches on top of the upstream KEDA project.
+
+## Repository Structure
+
+- `apis/` — Custom Resource Definition (CRD) API types
+- `controllers/` — Kubernetes controller reconcilers for ScaledObject, ScaledJob, etc.
+- `cmd/` — Main entry points (operator, adapter)
+- `vendor/` — Vendored Go dependencies (do not edit manually)
+
+## Tech Stack
+
+- Go
+- Kubernetes `controller-runtime`
+- Prometheus (metrics)
+
+## Key Conventions
+
+- This is a fork — keep InfoTrack-specific changes minimal and clearly marked with `// InfoTrack:` comments so they are easy to identify when rebasing upstream
+- Before adding a new scaler, check if upstream KEDA already has or is developing it
+- All new scalers must have unit tests in `*_test.go` alongside the scaler implementation
+- `vendor/` is managed by `go mod vendor` — never edit vendored files directly
+
+## Common Tasks
+
+```bash
+go build ./cmd/operator
+go test ./controllers/... ./pkg/...
+
+# Update vendor after go.mod changes
+go mod tidy && go mod vendor
+
+# Generate CRD manifests after API changes
+make manifests
+```
+
+## Upstream
+
+Based on [kedacore/keda](https://github.com/kedacore/keda). Periodically rebase from upstream `main` to pick up bug fixes and new scalers.
+
+## Notes
+
+- Default branch: `main`


### PR DESCRIPTION
## Summary

Adds a `CLAUDE.md` file to provide context for [Claude Code](https://claude.ai/code) (Anthropic's AI coding assistant) when engineers use it in this repository.

`CLAUDE.md` is automatically loaded by Claude Code at the start of each session and gives the AI accurate information about:
- Repository purpose and structure
- Tech stack and key directories
- Build/run commands
- Conventions and constraints specific to this codebase

This helps Claude Code give more accurate, repo-aware suggestions without needing manual context-setting each session.

No code changes — documentation only.